### PR TITLE
add missing entql.RelayConnection() for queries

### DIFF
--- a/templates/schema.tmpl
+++ b/templates/schema.tmpl
@@ -44,6 +44,7 @@ func ({{ $name }}) Annotations() []schema.Annotation {
 		},
 		{{- if .Query }}
 		entgql.QueryField(),
+		entgql.RelayConnection(),
 		{{- end}}
 	}
 }


### PR DESCRIPTION
Missed adding the `RelayConnection` for entgql. 