### PR TITLE
gofmt puts that at the top (alphabetical order)

### DIFF
--- a/templates/schema.tmpl
+++ b/templates/schema.tmpl
@@ -2,15 +2,15 @@
 package {{ .SchemaPkg }}
 
 import (
+	{{- if $.Query }}
+	"entgo.io/contrib/entgql"
+	{{- end }}
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/field"
 	{{- if $.WithHistoryTimeIndex }}
 	"entgo.io/ent/schema/index"
-	{{- end }}
-	{{- if $.Query }}
-	"entgo.io/contrib/entgql"
 	{{- end }}
 
 	"github.com/datumforge/enthistory"


### PR DESCRIPTION
So we dont get diffs on `gofmt` vs. what is generated