### PR TITLE
feat: add ability to use existing updated_ by field instead of adding the field

### DIFF
--- a/enthistory.go
+++ b/enthistory.go
@@ -11,6 +11,7 @@ type ExtensionOption = func(*HistoryExtension)
 type UpdatedBy struct {
 	key       string
 	valueType ValueType
+	Nillable  bool
 }
 
 // FieldProperties is a struct that holds the properties for the fields in the history schema
@@ -21,6 +22,7 @@ type FieldProperties struct {
 
 // Config is the configuration for the history extension
 type Config struct {
+	IncludeUpdatedBy bool
 	UpdatedBy        *UpdatedBy
 	Auditing         bool
 	SchemaPath       string
@@ -184,9 +186,22 @@ func WithSkipper(skipper string) ExtensionOption {
 // usually done via a middleware to track which users are making which changes
 func WithUpdatedBy(key string, valueType ValueType) ExtensionOption {
 	return func(h *HistoryExtension) {
+		h.config.IncludeUpdatedBy = true
 		h.config.UpdatedBy = &UpdatedBy{
 			key:       key,
 			valueType: valueType,
+			Nillable:  true,
+		}
+	}
+}
+
+// WithUpdatedByFromSchema uses the original update_by value in the schema and includes in the audit results
+func WithUpdatedByFromSchema(valueType ValueType, nillable bool) ExtensionOption {
+	return func(h *HistoryExtension) {
+		h.config.IncludeUpdatedBy = true
+		h.config.UpdatedBy = &UpdatedBy{
+			valueType: ValueTypeString,
+			Nillable:  nillable,
 		}
 	}
 }

--- a/generateschemas.go
+++ b/generateschemas.go
@@ -149,13 +149,19 @@ func getTemplateInfo(schema *load.Schema, config *Config, idType string) (*templ
 	if config.UpdatedBy != nil {
 		valueType := config.UpdatedBy.valueType
 
-		if valueType == ValueTypeInt {
+		switch valueType {
+		case ValueTypeInt:
 			info.UpdatedByValueType = "Int"
-		} else if valueType == ValueTypeString {
+		case ValueTypeString:
 			info.UpdatedByValueType = "String"
 		}
 
-		info.WithUpdatedBy = true
+		// if updated_by is enabled, add the updated_by fields
+		// do not include if the key is not set, this should then
+		// use the existing updated_by field
+		if config.UpdatedBy.key != "" {
+			info.WithUpdatedBy = true
+		}
 	}
 
 	info.WithHistoryTimeIndex = config.HistoryTimeIndex

--- a/templates/auditing.tmpl
+++ b/templates/auditing.tmpl
@@ -23,8 +23,10 @@ import (
 	{{- end }}
 )
 
+{{ $includeUpdatedBy := $.Annotations.HistoryConfig.IncludeUpdatedBy }}
 {{ $updatedByKey := extractUpdatedByKey $.Annotations.HistoryConfig.UpdatedBy }}
 {{ $updatedByValueType := extractUpdatedByValueType $.Annotations.HistoryConfig.UpdatedBy }}
+{{ $updatedByNillable := $.Annotations.HistoryConfig.UpdatedBy.Nillable }}
 
 type Change struct {
 	FieldName string
@@ -131,7 +133,7 @@ func (c Change) String(op enthistory.OpType) string {
 
 func (c *Client) Audit(ctx context.Context) ([][]string, error) {
 	records := [][]string{
-		{"Table", "Ref Id", "History Time", "Operation", "Changes"{{ if not (eq $updatedByKey "") }}, "Updated By" {{ end }}},
+		{"Table", "Ref Id", "History Time", "Operation", "Changes"{{ if $includeUpdatedBy }}, "Updated By" {{ end }}},
 	}
 	var record [][]string
 	var err error
@@ -149,19 +151,43 @@ func (c *Client) Audit(ctx context.Context) ([][]string, error) {
 	return records, nil
 }
 
+func (c *Client) AuditWithFilter(ctx context.Context, tableName string) ([][]string, error) {
+	records := [][]string{
+		{"Table", "Ref Id", "History Time", "Operation", "Changes"{{ if $includeUpdatedBy }}, "Updated By" {{ end }}},
+	}
+	var record [][]string
+	var err error
+
+	{{- range $n := $.Nodes }}
+	{{- if (hasSuffix $n.Name "History") }}
+
+	if tableName == "" || tableName == strings.Trim("{{ $n.Name }}", "History") {
+		record, err = audit{{ $n.Name }}(ctx, c.config)
+		if err != nil {
+			return nil, err
+		}
+
+		records = append(records, record...)
+	}
+	{{ end }}
+	{{- end }}
+
+	return records, nil
+}
+
 type record struct {
 	Table       string
 	RefId       any
 	HistoryTime time.Time
 	Operation   enthistory.OpType
 	Changes     []Change
-	{{- if not (eq $updatedByKey "") }}
-	UpdatedBy   *{{ $updatedByValueType }}
+	{{- if $includeUpdatedBy }}
+	UpdatedBy   {{ if $updatedByNillable}}*{{- end}}{{ $updatedByValueType }}
 	{{- end }}
 }
 
 func (r *record) toRow() []string {
-	{{- if not (eq $updatedByKey "") }}
+	{{- if $includeUpdatedBy }}
 	row := make([]string, 6)
 	{{- else }}
 	row := make([]string, 5)
@@ -178,10 +204,20 @@ func (r *record) toRow() []string {
 		}
 		row[4] = fmt.Sprintf("%s\n%s", row[4], change.String(r.Operation))
 	}
-	{{- if not (eq $updatedByKey "") }}
+	{{- if $includeUpdatedBy }}
+	{{- if $updatedByNillable }}
 	if r.UpdatedBy != nil {
 		row[5] = fmt.Sprintf("%v", *r.UpdatedBy)
 	}
+	{{- else if (eq $updatedByValueType "string") }}
+	if r.UpdatedBy != "" {
+		row[5] = fmt.Sprintf("%v", r.UpdatedBy)
+	}
+	{{- else }}
+		if r.UpdatedBy != 0 {
+		row[5] = fmt.Sprintf("%v", r.UpdatedBy)
+	}
+	{{- end}}
 	{{- end }}
 	return row
 }
@@ -227,7 +263,7 @@ func audit{{ $n.Name }}(ctx context.Context, config config) ([][]string, error) 
 				RefId:       curr.Ref,
 				HistoryTime: curr.HistoryTime,
 				Operation:   curr.Operation,
-				{{- if not (eq $updatedByKey "") }}
+				{{- if $includeUpdatedBy }}
 				UpdatedBy:   curr.UpdatedBy,
 				{{- end }}
 			}

--- a/templates/auditing.tmpl
+++ b/templates/auditing.tmpl
@@ -161,7 +161,7 @@ func (c *Client) AuditWithFilter(ctx context.Context, tableName string) ([][]str
 	{{- range $n := $.Nodes }}
 	{{- if (hasSuffix $n.Name "History") }}
 
-	if tableName == "" || tableName == strings.Trim("{{ $n.Name }}", "History") {
+	if tableName == "" || tableName == strings.TrimSuffix("{{ $n.Name }}", "History") {
 		record, err = audit{{ $n.Name }}(ctx, c.config)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Within our schemas, we generally use an `audit` mixin that adds the `updated_by` field to all our schemas. This prevents the usage of using the `updated_by` field in the history tables by `enthistory`. However, it is still nice to be able to include this in our `Audit` functionality. This PR adds the ability to use an _existing_ `updated_by` field in the `.Audit()` response. 

It also adds an `AuditWithFilter` that allows you to pre-filter (before the querieis) by the original table names, meaning if you want to see the `Organization` history, from the `OrganizationHistory` table, you can filter on `table: Organization` to retrieve all the data:


```graphql
query AuditLogs($where: AuditLogWhereInput) {
  auditLogs(where: $where) {
    edges {
      node {
        table
        time
        operation
        changes
        id
        updatedBy
      }
    }
  }
}
```

```json
{
  "where": {
    "table": "Organization",
    "operation": "UPDATE",
  }
}
```

Result:

```json
{
  "data": {
    "auditLogs": {
      "edges": [
        {
          "node": {
            "table": "Organization",
            "time": "2024-07-24T23:01:11Z",
            "operation": "UPDATE",
            "changes": [
              "updated_at: \"2024-07-18T17:26:02.792104Z\" -> \"2024-07-24T23:01:11.12287Z\"",
              "deleted_at: \"0001-01-01T00:00:00Z\" -> \"0001-01-01T00:00:00Z\"",
              "description: \"\" -> \"meowzers\""
            ],
            "id": "01J33E29S8HYFFG11C2JDM9N4K",
            "updatedBy": "01J33E1TX4JP7NP2EV4CYM1GH6"
          }
        },
        {
          "node": {
            "table": "Organization",
            "time": "2024-07-27T05:04:23Z",
            "operation": "UPDATE",
            "changes": [
              "updated_at: \"2024-07-24T23:01:11.12287Z\" -> \"2024-07-27T05:04:23.184054Z\"",
              "description: \"meowzers\" -> \"meow\""
            ],
            "id": "01J33E29S8HYFFG11C2JDM9N4K",
            "updatedBy": "01J33E1TX4JP7NP2EV4CYM1GH6"
          }
        }
      ]
    }
  },
  "extensions": {
    "auth": {
      "authentication_type": "pat"
    },
    "server_latency": "59.121292ms",
    "trace_id": "fFdiZPncPVngFfgSXuNqutrWZhtQwcFA"
  }
}
```
